### PR TITLE
docs: correct README license to GPL-3.0 (matches LICENSE file)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Contributions are welcome! Please read the [contributing guidelines](CONTRIBUTIN
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the GNU General Public License v3.0 (GPL-3.0) - see the [LICENSE](LICENSE) file for details.
 
 ## Contact
 


### PR DESCRIPTION
## What
The `LICENSE` file is the **GNU General Public License v3.0** (header: "GNU GENERAL PUBLIC LICENSE, Version 3"), but the README's License section claimed **"MIT License"** — a licensing mismatch that misleads users about their rights.

## Fix
`README.md` License section: "MIT License" → "GNU General Public License v3.0 (GPL-3.0)", matching the actual `LICENSE` file (the legally binding source of truth).

No relicensing — this only corrects the documentation to reflect the license already in force.

🤖 Generated with [Claude Code](https://claude.com/claude-code)